### PR TITLE
Fix for empty directory after running jx_indexer in experiment mode.

### DIFF
--- a/junction_database/index.py
+++ b/junction_database/index.py
@@ -389,6 +389,13 @@ def create_phenotype_table(cancer_phens, tissue_phens, id_file, index_db,
 
     full_df = pd.concat([tcga_phen, gtex_phen], ignore_index=True).fillna('')
 
+    cols = ["TCGA_id", "case_id", "gender", "gleason", "hepatitis_status",
+            "hnsc_location", "hpv_status", "meso_subtype", "primary_type",
+            "project", "project_type_label", "recount_id", "sample_origin",
+            "seminoma", "stage", "tumor_normal", "ucs_subtype",
+            "universal_id", "vital_status"]
+    full_df = full_df[cols]
+
     for ind, row in full_df.iterrows():
         # jx_info = list(map(str, jx_info + cds_cols))
 


### PR DESCRIPTION
This reorders the columns of `full_df`, solving the issue of observing an empty directory after running `jx_indexer` in `experiment` mode.

The reason for the empty directory originated from an incorrectly built database, which was due to write operations that used an incorrect column order.